### PR TITLE
Qualify table schema when copying out

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -111,8 +111,9 @@ impl Table {
             return query;
         }
         let mut query = format!(
-            "select {} from {}",
+            "select {} from {}.{}",
             &self.column_list(),
+            &self.schema.sql_identifier(),
             &self.name.sql_identifier()
         );
         if let Some(org_scope) = self


### PR DESCRIPTION
Previously this was getting confused because there were two tables named `products` in different schemas on the default search path. The query that was constructed was correct for the chosen schema, but the other schema was ahead in the search path, causing the `COPY (...) TO stdout` query to pick up data from the wrong table.