### PR TITLE
Summarize dumped sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6945cc5422176fc5e602e590c2878d2c2acd9a4fe20a4baa7c28022521698ec6"
+
+[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +574,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04619f94ba0cc80999f4fc7073607cb825bc739a883cb6d20900fc5e009d6b0d"
 dependencies = [
+ "array-init",
  "bytes",
  "fallible-iterator",
  "postgres-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 exclude = ["screenshots", ".vscode", "release.sh", "Brewfile", ".github"]
 
 [dependencies]
-postgres = "0.19.2"
+postgres = { version = "0.19.2", features = ["array-impls"] }
 lazy_static = "1.4.0"
 dialoguer = "0.10.0"
 indicatif = "0.16.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,7 +182,6 @@ impl Table {
 struct Column {
     pub name: String,
     pub is_nullable: bool,
-    pub position: i32,
 }
 
 fn get_tables(options: &Options) -> Result<Vec<Table>, Box<dyn Error>> {
@@ -222,16 +221,12 @@ fn get_tables(options: &Options) -> Result<Vec<Table>, Box<dyn Error>> {
                 let table_size: u64 = table_size_s.parse().unwrap_or(0);
                 let table_rows_s: String = row.get("table_rows");
                 let table_rows: u64 = table_rows_s.parse().unwrap_or(0);
-                let column_names: Vec<&str> = row.get("column_names");
+                let column_names: Vec<String> = row.get("column_names");
                 let column_nullables: Vec<bool> = row.get("column_nullables");
-                let columns = (1..)
-                    .zip(column_names)
+                let columns = column_names
+                    .into_iter()
                     .zip(column_nullables)
-                    .map(|((position, name), is_nullable)| Column {
-                        name: name.to_owned(),
-                        is_nullable,
-                        position,
-                    })
+                    .map(|(name, is_nullable)| Column { name, is_nullable })
                     .collect();
                 Some(Table {
                     name: table_name,

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,7 +243,7 @@ fn get_tables(options: &Options) -> Result<Vec<Table>, Box<dyn Error>> {
         r#"
         select
           tables.table_name,
-          pg_total_relation_size(tables.table_schema || '.' || tables.table_name)::text as table_size,
+          pg_total_relation_size(pg_class.oid)::text as table_size,
           max(pg_class.reltuples::int8)::text as table_rows, -- https://wiki.postgresql.org/wiki/Count_estimate
           array_agg(columns.column_name::text order by columns.ordinal_position) as column_names,
           array_agg(columns.is_nullable = 'YES' order by columns.ordinal_position) as column_nullables
@@ -259,8 +259,8 @@ fn get_tables(options: &Options) -> Result<Vec<Table>, Box<dyn Error>> {
           and pg_class.relname = tables.table_name)
         where tables.table_schema = {schema}
         and tables.table_type = 'BASE TABLE'
-        group by tables.table_schema, tables.table_name
-        order by tables.table_schema, tables.table_name
+        group by tables.table_name, pg_class.oid
+        order by tables.table_name
         "#,
         schema = options.schema.sql_value(),
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,9 +64,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let options = Options::load()?;
     let mut client = Client::connect(&options.database_url, NoTls)?;
 
-    client
-        .query("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;", &[])
-        .unwrap();
+    client.query("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;", &[])?;
 
     let tables = get_tables(&options)?;
 
@@ -88,7 +86,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
     pb.finish_with_message(format!("Dumped {} tables", tables.len()));
 
-    client.query("ROLLBACK", &[]).unwrap();
+    client.query("ROLLBACK", &[])?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,9 +69,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     let tables = get_tables(&options)?;
 
     let pb = ProgressBar::new(tables.len() as u64);
-    pb.set_style(
-        ProgressStyle::default_bar().template("{msg:>30.bold} {spinner} {wide_bar} eta {eta}"),
+    let pb_template = format!(
+        "{{msg:>{width}.bold}} {{spinner}} {{wide_bar}} eta {{eta}} ",
+        width = tables
+            .iter()
+            .map(|table| table.name.len())
+            .max()
+            .unwrap_or(30)
     );
+    pb.set_style(ProgressStyle::default_bar().template(&pb_template));
     pb.enable_steady_tick(250);
 
     for table in tables.iter() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let options = Options::load()?;
     let mut client = Client::connect(&options.database_url, NoTls)?;
 
-    client.query("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;", &[])?;
+    // Restrict `search_path` to just the one schema.
+    client.execute(&format!("SET SCHEMA {}", options.schema.sql_value()), &[])?;
+    client.execute("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;", &[])?;
 
     let tables = get_tables(&options)?;
 


### PR DESCRIPTION
When all tables have been dumped, this prints out a list of the tables dumped sorted by the size of the data dumped, with the largest being last. This may help us prioritize which tables we want to write custom override queries for.

This PR also:

- Doesn't buffer the whole table's data in memory.
- Stops the progress bar from jumping around (which was causes by long table names).
- Adds an `--estimate-only` flag.
- Restricts the schema to just the one configured. This prevents accidentally selecting from similarly named tables in other schemas on the search path.
