### PR TITLE
Have truncate cascade

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         if options.truncate {
             writeln!(
                 std::io::stdout(),
-                "TRUNCATE TABLE\n  {}\n;",
+                "TRUNCATE TABLE\n  {}\nCASCADE;",
                 // `iter_intersperse` is an unstable feature in the standard
                 // library. When it stabilises, we can remove `itertools` and
                 // just chain into `Iterator.intersperse` instead.


### PR DESCRIPTION
I was unable to load data from a dump recently due to a FK constraint since `load` does not drop all schemas beforehand, meaning it's about to insert data into the db when it already has data. It tried to truncate all of the tables but it failed due to the FK constraint. I'm guessing the tables would have to be truncated in a certain order, but short of figuring that out, I went into the dump and manually added `CASCADE` right before the semicolon, which allowed me to proceed. The comment mentions we can't truncate as we go along, but cascading when we truncate all tables seems to work ok.