### PR TITLE
Do not attempt to copy autogenerated columns

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -279,7 +279,9 @@ fn get_tables(options: &Options) -> Result<Vec<Table>, Box<dyn Error>> {
         join information_schema.columns on (
           columns.table_catalog = tables.table_catalog
           and columns.table_schema = tables.table_schema
-          and columns.table_name = tables.table_name)
+          and columns.table_name = tables.table_name
+          and columns.is_generated = 'NEVER'
+        )
         join pg_namespace on (
           pg_namespace.nspname = tables.table_schema)
         join pg_class on (


### PR DESCRIPTION
<!-- Please do not discuss the specifics of your schema here. If necessary, provide a minimal reproducible example. -->

Autogenerated columns cannot be written to, and `COPY` is considered writing to one. 

The value for ```information_schema.column.is_generated``` is only ever either `ALWAYS` or `NEVER`. 