### PR TITLE
Upgrade Indicatif

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,14 +350,13 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.16.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+checksum = "fcc42b206e70d86ec03285b123e65a5458c92027d1fb2ae3555878b8113b3ddf"
 dependencies = [
  "console",
- "lazy_static",
  "number_prefix",
- "regex",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.4.2"
 [dependencies]
 clap = {version = "3.1.5", features = ["derive", "wrap_help"]}
 dialoguer = "0.10.0"
-indicatif = "0.16.2"
+indicatif = "0.17.0"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
 postgres = {version = "0.19.2", features = ["array-impls"]}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use std::collections::HashSet;
 use std::error::Error;
 use std::io::Write;
 use std::path::Path;
+use std::time::Duration;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -89,15 +90,19 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let pb = ProgressBar::new(tables.len() as u64);
     let pb_template = format!(
-        "{{msg:>{width}.bold}} {{spinner}} {{wide_bar}} eta {{eta}} ",
+        "{{msg:>{width}.bold}} {{spinner:.blue/white}} {{wide_bar:.blue/white}} eta {{eta}}",
         width = tables
             .iter()
             .map(|table| table.name.len())
             .max()
             .unwrap_or(30)
     );
-    pb.set_style(ProgressStyle::default_bar().template(&pb_template));
-    pb.enable_steady_tick(250);
+    pb.set_style(
+        ProgressStyle::with_template(&pb_template)
+            .unwrap()
+            .progress_chars("█▉▊▋▌▍▎▏  "),
+    );
+    pb.enable_steady_tick(Duration::from_millis(250));
 
     if options.estimate_only {
         let mut total_size: u64 = 0; // Estimate in kibibytes.


### PR DESCRIPTION
Indicatif (the progress bar library) 0.17 boasts 95x lower overhead and a host of other features including colors. 

https://github.com/console-rs/indicatif/releases/tag/0.17.0

Note that while I've added colors to the progress template, they won't render if the _any_ output is redirected to a file even though STDERR is always a terminal. This can be overridden with `CLICOLOR_FORCE=true`.