### PR TITLE
Make DB URL optional/overridable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["postgresql"]
 license = "MIT OR Apache-2.0"
 name = "pg_parcel"
 repository = "https://github.com/Blissfully/pg_parcel"
-version = "0.4.2"
+version = "0.4.3"
 
 [dependencies]
 clap = {version = "3.1.5", features = ["derive", "wrap_help"]}

--- a/src/inputfile.rs
+++ b/src/inputfile.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 pub struct InputFile {
     pub column_name: String,
     pub schema_name: String,
-    pub database_url: String,
+    pub database_url: Option<String>,
     pub skip_tables: Option<HashSet<String>>,
     pub overrides: Option<HashMap<String, String>>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,10 @@ struct Args {
     #[clap(short, long, display_order = 2)]
     id: String,
 
+    /// Override database URL in parcel config.
+    #[clap(long, display_order = 3)]
+    database_url: Option<String>,
+
     /// Insert a `TRUNCATE` command before any `COPY` commands.
     ///
     /// This will truncate every table found in the schema *except* those that
@@ -35,7 +39,7 @@ struct Args {
     /// `TRUNCATE` command will likely fail. Should this happen, instead of
     /// skipping a table, include it with an override query containing a `WHERE
     /// false` condition.
-    #[clap(long, display_order = 3)]
+    #[clap(long, display_order = 4)]
     truncate: bool,
 
     /// Prints a report estimating row count and size of the data to be dumped
@@ -67,7 +71,10 @@ impl Options {
         let options = Options {
             column_name: file.column_name,
             column_value: args.id,
-            database_url: file.database_url,
+            database_url: file
+                .database_url
+                .or(args.database_url)
+                .unwrap_or_else(|| "postgres://localhost:5432/postgres".to_string()),
             schema: file.schema_name,
             skip_tables: file.skip_tables.unwrap_or_default(),
             overrides: file.overrides.unwrap_or_default(),


### PR DESCRIPTION
Current behaviour: `database_url` is taken directly from the configuration file.

New behaviour: `database_url` is taken via the following priority:
1. CLI argument `--database-url`
2. Configuration file `database_url`
3. The string `postgres://localhost:5432/postgres`