### PR TITLE
Avoid `.unwrap()` & remove `dialoguer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,17 +172,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d6b4fabcd9e97e1df1ae15395ac7e49fb144946a0d453959dc2696273b9da"
-dependencies = [
- "console",
- "tempfile",
- "zeroize",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,7 +578,6 @@ name = "pg_parcel"
 version = "0.4.3"
 dependencies = [
  "clap",
- "dialoguer",
  "indicatif",
  "itertools",
  "lazy_static",
@@ -1273,9 +1261,3 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
-
-[[package]]
-name = "zeroize"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50344758e2f40e3a1fcfc8f6f91aa57b5f8ebd8d27919fe6451f15aaaf9ee608"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,11 @@ repository = "https://github.com/Blissfully/pg_parcel"
 version = "0.4.3"
 
 [dependencies]
-clap = {version = "3.1.5", features = ["derive", "wrap_help"]}
-dialoguer = "0.10.0"
+clap = { version = "3.1.5", features = ["derive", "wrap_help"] }
 indicatif = "0.17.0"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
-postgres = {version = "0.19.4", features = ["array-impls"]}
+postgres = { version = "0.19.4", features = ["array-impls"] }
 native-tls = "0.2.10"
 postgres-native-tls = "0.5.0"
 regex = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,13 +87,12 @@ impl Options {
     }
 }
 
-fn pg_client(options: &Options) -> Result<Client, postgres::Error> {
+fn pg_client(options: &Options) -> Result<Client, Box<dyn Error>> {
     let connector = TlsConnector::builder()
         .danger_accept_invalid_certs(true)
-        .build()
-        .unwrap();
+        .build()?;
     let connector = MakeTlsConnector::new(connector);
-    Client::connect(&options.database_url, connector)
+    Ok(Client::connect(&options.database_url, connector)?)
 }
 
 fn main() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
Something I suggested in #21 which I approved without realising it would auto-merge. Plus I noticed – thanks to [cargo-udeps](https://lib.rs/crates/cargo-udeps) – that `dialoguer` is no longer used.