### PR TITLE
Add Smoke tests to CI and release flows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
   build-linux:
     name: Build Linux
     runs-on: ubuntu-22.04
+    needs: [ check ]
     steps:
       - name: Install dev tools
         run: |
@@ -65,6 +66,7 @@ jobs:
   build-aarch64-apple-darwin:
     name: Build macOS ARM
     runs-on: macos-latest
+    needs: [ check ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -78,12 +80,14 @@ jobs:
         with:
           command: build
           args: --release --target aarch64-apple-darwin
-      - name: Smoke test
-        run: arch -arm64e target/aarch64-apple-darwin/release/pg_parcel --help
+  # There's no ARM64 macos available in github actions.
+  #      - name: Smoke test
+  #        run: arch -arm64e target/aarch64-apple-darwin/release/pg_parcel --help
 
   build-x86_64-apple-darwin:
     name: Build macOS Intel
     runs-on: macos-latest
+    needs: [ check ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -103,11 +107,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-22.04
+    needs: [ check ]
     steps:
-      - name: Install dev tools
-        run: |
-          sudo apt update
-          sudo apt -y install musl-tools libssl-dev
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           toolchain: stable
           override: true
           target: x86_64-unknown-linux-musl
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -75,7 +75,7 @@ jobs:
           toolchain: stable
           override: true
           target: aarch64-apple-darwin
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -96,7 +96,7 @@ jobs:
           toolchain: stable
           override: true
           target: x86_64-apple-darwin
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check:
-    name: Format, Clippy, Build
+    name: Format, Clippy
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
@@ -37,11 +37,68 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  build-linux:
+    name: Build Linux
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install dev tools
+        run: |
+          sudo apt update
+          sudo apt -y install musl-tools libssl-dev
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: x86_64-unknown-linux-musl
+      - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
-        name: build --no-default-features
         with:
           command: build
-          args: --target x86_64-unknown-linux-musl --no-default-features
+          args: --release --target x86_64-unknown-linux-musl
+      - name: Smoke test
+        run: target/x86_64-unknown-linux-musl/release/pg_parcel --help
+
+
+  build-aarch64-apple-darwin:
+    name: Build macOS ARM
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: aarch64-apple-darwin
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target aarch64-apple-darwin
+      - name: Smoke test
+        run: arch -arm64e target/aarch64-apple-darwin/release/pg_parcel --help
+
+  build-x86_64-apple-darwin:
+    name: Build macOS Intel
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: x86_64-apple-darwin
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target x86_64-apple-darwin
+      - name: Smoke test
+        run: target/x86_64-apple-darwin/release/pg_parcel --help
 
   test:
     name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     name: Format, Clippy
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dev tools
         run: |
           sudo apt update
@@ -47,7 +47,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt -y install musl-tools libssl-dev
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -68,7 +68,7 @@ jobs:
     runs-on: macos-latest
     needs: [ check ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -89,7 +89,7 @@ jobs:
     runs-on: macos-latest
     needs: [ check ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [ check ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           command: build
           args: --release --target x86_64-apple-darwin
+      - name: Smoke test
+        run: target/x86_64-apple-darwin/release/pg_parcel --help
       - uses: actions/upload-artifact@v2
         with:
           name: x86_64-apple-darwin
@@ -71,6 +73,8 @@ jobs:
             -output pg_parcel-apple-darwin \
             pg_parcel-x86_64-apple-darwin/pg_parcel \
             pg_parcel-aarch64-apple-darwin/pg_parcel
+      - name: Smoke test
+        run: pg_parcel-apple-darwin --help
       - uses: actions/upload-artifact@v2
         with:
           name: apple-darwin
@@ -97,6 +101,8 @@ jobs:
         with:
           command: build
           args: --release --target x86_64-unknown-linux-musl
+      - name: Smoke test
+        run: target/x86_64-unknown-linux-musl/release/pg_parcel --help
       - uses: actions/upload-artifact@v2
         with:
           name: linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 jobs:
-  aarch64-apple-darwin:
+  aarch64-apple-darwin-release:
     name: Build macOS ARM
     runs-on: macos-latest
     steps:
@@ -28,7 +28,7 @@ jobs:
           path: target/aarch64-apple-darwin/release/pg_parcel
           if-no-files-found: error
 
-  x86_64-apple-darwin:
+  x86_64-apple-darwin-release:
     name: Build macOS Intel
     runs-on: macos-latest
     steps:
@@ -50,10 +50,10 @@ jobs:
           path: target/x86_64-apple-darwin/release/pg_parcel
           if-no-files-found: error
 
-  macos-universal:
+  macos-universal-release:
     name: Build macOS Universal
     runs-on: macos-latest
-    needs: [aarch64-apple-darwin, x86_64-apple-darwin]
+    needs: [aarch64-apple-darwin-release, x86_64-apple-darwin-release]
     steps:
       - uses: actions/download-artifact@v2
         with:
@@ -77,7 +77,7 @@ jobs:
           path: pg_parcel-apple-darwin
           if-no-files-found: error
 
-  build-linux:
+  build-linux-release:
     name: Build Linux
     runs-on: ubuntu-22.04
     steps:
@@ -105,7 +105,7 @@ jobs:
 
   create-release:
     name: Create release
-    needs: [macos-universal, build-linux]
+    needs: [macos-universal-release, build-linux-release]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build macOS ARM
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -32,7 +32,7 @@ jobs:
     name: Build macOS Intel
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -89,7 +89,7 @@ jobs:
         run: | 
           sudo apt update
           sudo apt -y install musl-tools libssl-dev
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           toolchain: stable
           override: true
           target: aarch64-apple-darwin
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -39,7 +39,7 @@ jobs:
           toolchain: stable
           override: true
           target: x86_64-apple-darwin
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -96,7 +96,7 @@ jobs:
           toolchain: stable
           override: true
           target: x86_64-unknown-linux-musl
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: build


### PR DESCRIPTION
Added smoke tests to ensure the binary we produce can be executed.

for MacOS ARM64, we are cross-compiling as there's currently no support for MacOS ARM64 image in GH Actions.
Due to the cross-compilation, we can't run a smoke test there.